### PR TITLE
Support BUF gates in Reverie

### DIFF
--- a/companion/src/instruction/bristol.rs
+++ b/companion/src/instruction/bristol.rs
@@ -63,6 +63,11 @@ impl Parser<Instruction<BitScalar>> for InsParser {
                 let dst = ins[0].parse().unwrap();
                 Ok(Some(Instruction::Branch(dst)))
             }
+            "BUF" => {
+                let src = ins[0].parse().unwrap();
+                let dst = ins[1].parse().unwrap();
+                Ok(Some(Instruction::AddConst(dst, src, BitScalar::ZERO)))
+            }
             _ => unimplemented!(),
         }
     }


### PR DESCRIPTION
It's difficult to eliminate buffer gates at the stage of BLIF to Bristol conversion, and expensive to do it in Yosys. Fortunately, it's pretty trivial to just evaluate them under Reverie.

Admittedly, we're offsetting a one-time cost (eliminating them at netlist synthesis) at the expense of having larger circuit files and making Reverie do more work at runtime. That said, having support for buffer gates in Reverie will allow us to pick and choose where we want to invest that time when we're doing development.