### PR TITLE
reverie -> reverie-zk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 keywords = ["crypto", "cryptography", "zero-knowledge"]
 categories = ["cryptography"]
 
+[lib]
+name = "reverie"
+
 [package.metadata.release]
 no-dev-version = true
 disable-publish = true # handled by GitHub Actions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "reverie"
+name = "reverie-zk"
 description = "An efficient implementation of the NIZKPoK outlined in KKW 2018"
 license = "AGPL-3.0"
 homepage = "https://github.com/trailofbits/reverie"

--- a/companion/Cargo.toml
+++ b/companion/Cargo.toml
@@ -12,6 +12,6 @@ async-std = "*"
 async-stream = "0.2.1"
 clap = "2.33.1"
 rand = "0.7.3"
-reverie = {path = "../"}
+reverie = { path = "../", package = "reverie-zk" }
 serde = {version = "1.0", features = ["derive"]}
 rayon = "1.4"

--- a/companion/Cargo.toml
+++ b/companion/Cargo.toml
@@ -12,6 +12,6 @@ async-std = "*"
 async-stream = "0.2.1"
 clap = "2.33.1"
 rand = "0.7.3"
-reverie = { path = "../", package = "reverie-zk" }
+reverie-zk = { path = "../" }
 serde = {version = "1.0", features = ["derive"]}
 rayon = "1.4"


### PR DESCRIPTION
This renames the Cargo *package name* to `reverie-zk`, while retaining the *library name* as `reverie`.