### PR TITLE
Fix Nightly Build by Allowing Uppercase Acronyms

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
         run: cargo fmt
 
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings -A clippy::upper-case-acronyms
 
       - name: Build
         run: cargo build


### PR DESCRIPTION
Silences the uppercase acronym warning that is now causing clippy to fail. 

Unfortunately we don't seem to have the option yet of configuring lints in a file: https://github.com/rust-lang/cargo/issues/5034

Alternatively, we could find+replace the variable names clippy doesn't like.