### PR TITLE
Check that Companion builds as part of CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,3 +35,8 @@ jobs:
 
       - name: Test
         run: cargo test
+        
+      - name: Build Companion
+        run: |
+          cd companion
+          cargo build


### PR DESCRIPTION
We run various checks on the repository root, but we don't actually check that the companion builds properly.