### PR TITLE
Fix Quadratic Runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "An efficient implementation of the NIZKPoK outlined in KKW 2018"
 license = "AGPL-3.0"
 homepage = "https://github.com/trailofbits/reverie"
 repository = "https://github.com/trailofbits/reverie"
-version = "0.2.1-rc.4"
+version = "0.2.1-rc.5"
 authors = [
     "Mathias Hall-Andersen <mathias@hall-andersen.dk>",
     "William Woodruff <william@trailofbits.com>"

--- a/companion/src/fieldswitched.rs
+++ b/companion/src/fieldswitched.rs
@@ -281,7 +281,6 @@ async fn oneshot<WP: Parser<BitScalar> + Send + 'static>(
         program.arithmetic.clone(),
     ));
 
-    // TODO (ehennenfent) Do we need to do anything else to check the output here?
     Ok(verifier_output)
 }
 

--- a/companion/src/main.rs
+++ b/companion/src/main.rs
@@ -22,6 +22,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 
 use rayon::prelude::*;
+use reverie::fieldswitching::util::DedupMap;
 use std::collections::HashSet;
 
 const MAX_VEC_SIZE: usize = 1024 * 1024 * 1024;
@@ -160,7 +161,7 @@ async fn prove<
         OsRng.gen(),      // seed
         &branches[..],    // branches
         program.rewind(), // program
-        (HashSet::new(), vec![]),
+        (HashSet::new(), DedupMap::new()),
     );
     write_vec(&mut proof, &preprocessing.serialize()[..])?;
 
@@ -172,7 +173,7 @@ async fn prove<
         branch_index,
         program.rewind(),
         witness.rewind(),
-        (HashSet::new(), vec![]),
+        (HashSet::new(), DedupMap::new()),
         (vec![], vec![]),
     )
     .await;
@@ -185,7 +186,7 @@ async fn prove<
         send,
         program.rewind(),
         witness.rewind(),
-        (HashSet::new(), vec![]),
+        (HashSet::new(), DedupMap::new()),
         vec![],
         vec![],
     ));
@@ -226,7 +227,11 @@ async fn verify<
         .expect("Failed to deserialize proof after preprocessing");
 
     let pp_output = match preprocessing
-        .verify(&branches[..], program.rewind(), (HashSet::new(), vec![]))
+        .verify(
+            &branches[..],
+            program.rewind(),
+            (HashSet::new(), DedupMap::new()),
+        )
         .await
     {
         Some(output) => output,
@@ -243,7 +248,7 @@ async fn verify<
         online::StreamingVerifier::new(program.rewind(), online).verify(
             None,
             recv,
-            (HashSet::new(), vec![]),
+            (HashSet::new(), DedupMap::new()),
         ),
     );
 

--- a/companion/src/main.rs
+++ b/companion/src/main.rs
@@ -22,6 +22,7 @@ use rand::rngs::OsRng;
 use rand::Rng;
 
 use rayon::prelude::*;
+use std::collections::HashSet;
 
 const MAX_VEC_SIZE: usize = 1024 * 1024 * 1024;
 
@@ -159,7 +160,7 @@ async fn prove<
         OsRng.gen(),      // seed
         &branches[..],    // branches
         program.rewind(), // program
-        (vec![], vec![]),
+        (HashSet::new(), vec![]),
     );
     write_vec(&mut proof, &preprocessing.serialize()[..])?;
 
@@ -171,7 +172,7 @@ async fn prove<
         branch_index,
         program.rewind(),
         witness.rewind(),
-        (vec![], vec![]),
+        (HashSet::new(), vec![]),
         (vec![], vec![]),
     )
     .await;
@@ -184,7 +185,7 @@ async fn prove<
         send,
         program.rewind(),
         witness.rewind(),
-        (vec![], vec![]),
+        (HashSet::new(), vec![]),
         vec![],
         vec![],
     ));
@@ -225,7 +226,7 @@ async fn verify<
         .expect("Failed to deserialize proof after preprocessing");
 
     let pp_output = match preprocessing
-        .verify(&branches[..], program.rewind(), (vec![], vec![]))
+        .verify(&branches[..], program.rewind(), (HashSet::new(), vec![]))
         .await
     {
         Some(output) => output,
@@ -242,7 +243,7 @@ async fn verify<
         online::StreamingVerifier::new(program.rewind(), online).verify(
             None,
             recv,
-            (vec![], vec![]),
+            (HashSet::new(), vec![]),
         ),
     );
 

--- a/src/algebra/z64/scalar.rs
+++ b/src/algebra/z64/scalar.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use std::fmt;
 
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Scalar(pub(super) u64);
+pub struct Scalar(pub u64);
 
 impl LocalOperation for Scalar {}
 

--- a/src/fieldswitching/online.rs
+++ b/src/fieldswitching/online.rs
@@ -103,16 +103,9 @@ impl<D: Domain, D2: Domain> Proof<D, D2> {
                             if i >= D2::NR_OF_BITS {
                                 break;
                             }
-                            let val: D::Scalar = out_map
-                                .get(&src_bit)
-                                .expect(
-                                    format!(
-                                        "Couldn't find wire {} in boolean circuit output",
-                                        src_bit
-                                    )
-                                    .as_str(),
-                                )
-                                .clone();
+                            let val: D::Scalar = *out_map.get(&src_bit).unwrap_or_else(|| {
+                                panic!("Couldn't find wire {} in boolean circuit output", src_bit)
+                            });
                             next = next + convert_bit::<D, D2>(val) * pow_two;
                             pow_two = two * pow_two;
                         }

--- a/src/fieldswitching/preprocessing.rs
+++ b/src/fieldswitching/preprocessing.rs
@@ -223,11 +223,7 @@ impl<D: Domain, D2: Domain> Proof<D, D2> {
         }
 
         // recompute the opened repetitions
-        let opened_roots: Vec<[u8; KEY_SIZE]> = roots
-            .iter()
-            .filter(|v| v.is_some())
-            .map(|v| v.unwrap())
-            .collect();
+        let opened_roots: Vec<[u8; KEY_SIZE]> = roots.into_iter().flatten().collect();
 
         debug_assert_eq!(
             opened_roots.len(),

--- a/src/fieldswitching/util.rs
+++ b/src/fieldswitching/util.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::Arc;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DedupMap<K> {
     underlying: Vec<Vec<K>>,
     mapper: HashMap<K, usize>,

--- a/src/fieldswitching/util.rs
+++ b/src/fieldswitching/util.rs
@@ -4,8 +4,9 @@ use crate::crypto::{kdf, Prg, KEY_SIZE};
 use crate::preprocessing::util::{PartialShareGenerator, ShareGenerator};
 use crate::{ConnectionInstruction, Instruction};
 use std::sync::Arc;
+use std::collections::HashSet;
 
-pub type FieldSwitchingIo = (Vec<usize>, Vec<Vec<usize>>);
+pub type FieldSwitchingIo = (HashSet<usize>, Vec<Vec<usize>>);
 pub type FullProgram<D, D2> = (
     Vec<ConnectionInstruction>,
     Arc<Vec<Instruction<<D as Domain>::Scalar>>>,

--- a/src/online/prover.rs
+++ b/src/online/prover.rs
@@ -17,6 +17,7 @@ use async_channel::{Receiver, SendError, Sender};
 use async_std::task;
 use std::iter::Cloned;
 use std::slice::Iter;
+use std::collections::HashSet;
 
 /// A type alias for a tuple of a program slice and its witness slice.
 type ProgWitSlice<D> = (Arc<Instructions<D>>, Arc<Vec<<D as Domain>::Scalar>>);
@@ -313,7 +314,7 @@ impl<D: Domain, I: Iterator<Item = D::Scalar>> Prover<D, I> {
     fn process_input<WW: Writer<D::Scalar>>(
         &mut self,
         masked_witness: &mut WW,
-        fieldswitching_input: Vec<usize>,
+        fieldswitching_input: HashSet<usize>,
         eda_composed: &mut Cloned<Iter<D::Sharing>>,
         value: D::Scalar,
         masks: &mut Cloned<Iter<D::Sharing>>,

--- a/src/online/verifier.rs
+++ b/src/online/verifier.rs
@@ -18,6 +18,7 @@ use crate::fieldswitching::util::FieldSwitchingIo;
 use async_std::task;
 use std::iter::Cloned;
 use std::slice::Iter;
+use std::collections::HashSet;
 
 const DEFAULT_CAPACITY: usize = 1024;
 
@@ -419,7 +420,7 @@ impl<D: Domain> StreamingVerifier<D> {
         }
 
         fn process_input<D: Domain>(
-            fieldswitching_input: Vec<usize>,
+            fieldswitching_input: HashSet<usize>,
             mut wires: &mut VecMap<D::Scalar>,
             witness: &mut Cloned<Iter<D::Scalar>>,
             mut nr_of_wires: usize,

--- a/src/preprocessing/mod.rs
+++ b/src/preprocessing/mod.rs
@@ -412,7 +412,9 @@ mod tests {
     use super::super::algebra::gf2::{BitScalar, Gf2P8};
     use super::*;
 
+    use crate::fieldswitching::util::DedupMap;
     use rand::Rng;
+    use std::collections::HashSet;
 
     #[test]
     fn test_preprocessing_n8() {
@@ -426,8 +428,18 @@ mod tests {
         let seed: [u8; KEY_SIZE] = rng.gen();
         let branch: Vec<BitScalar> = vec![];
         let branches: Vec<&[BitScalar]> = vec![&branch];
-        let proof = Proof::<Gf2P8>::new(seed, &branches[..], program.clone(), (vec![], vec![]));
-        assert!(task::block_on(proof.0.verify(&branches[..], program, (vec![], vec![]))).is_some());
+        let proof = Proof::<Gf2P8>::new(
+            seed,
+            &branches[..],
+            program.clone(),
+            (HashSet::new(), DedupMap::new()),
+        );
+        assert!(task::block_on(proof.0.verify(
+            &branches[..],
+            program,
+            (HashSet::new(), DedupMap::new())
+        ))
+        .is_some());
     }
 }
 

--- a/src/preprocessing/mod.rs
+++ b/src/preprocessing/mod.rs
@@ -233,11 +233,7 @@ impl<D: Domain> Proof<D> {
         }
 
         // recompute the opened repetitions
-        let opened_roots: Vec<[u8; KEY_SIZE]> = roots
-            .iter()
-            .filter(|v| v.is_some())
-            .map(|v| v.unwrap())
-            .collect();
+        let opened_roots: Vec<[u8; KEY_SIZE]> = roots.into_iter().flatten().collect();
 
         debug_assert_eq!(
             opened_roots.len(),

--- a/src/preprocessing/preprocessing.rs
+++ b/src/preprocessing/preprocessing.rs
@@ -7,6 +7,7 @@ use crate::util::{VecMap, Writer};
 use crate::Instruction;
 
 use std::marker::PhantomData;
+use std::collections::HashSet;
 
 /// Implementation of pre-processing phase used by the prover during online execution
 pub struct PreprocessingExecution<D: Domain> {
@@ -123,7 +124,7 @@ impl<D: Domain> PreprocessingExecution<D> {
     pub fn prove(
         &mut self,
         program: &[Instruction<D::Scalar>],
-        fieldswitching_input: Vec<usize>,
+        fieldswitching_input: HashSet<usize>,
         fieldswitching_output: Vec<Vec<usize>>,
         nr_of_wires: usize,
     ) -> usize {
@@ -133,7 +134,7 @@ impl<D: Domain> PreprocessingExecution<D> {
         let mut batch_a = vec![D::Batch::ZERO; D::PLAYERS];
         let mut batch_b = vec![D::Batch::ZERO; D::PLAYERS];
         let mut nr_of_wires = nr_of_wires;
-        let mut fieldswitching_output_done = Vec::new();
+        let mut fieldswitching_output_done: HashSet<usize> = HashSet::new();
 
         for step in program {
             debug_assert!(self.share_a.len() < D::Batch::DIMENSION);
@@ -237,7 +238,7 @@ impl<D: Domain> PreprocessingExecution<D> {
                             break;
                         }
                     }
-                    fieldswitching_output_done.push(src);
+                    fieldswitching_output_done.insert(src);
                     let mut contains_all = true;
                     for item in out_list.clone() {
                         if !fieldswitching_output_done.contains(&item) {

--- a/src/preprocessing/prover.rs
+++ b/src/preprocessing/prover.rs
@@ -5,6 +5,7 @@ use crate::consts::{CONTEXT_RNG_BRANCH_MASK, CONTEXT_RNG_BRANCH_PERMUTE, CONTEXT
 use crate::crypto::{kdf, Hash, MerkleSet, MerkleSetProof, Prg, RingHasher, TreePrf, KEY_SIZE};
 use crate::util::{VecMap, Writer};
 use crate::Instruction;
+use std::collections::HashSet;
 
 /// Implementation of pre-processing phase used by the prover during online execution
 pub struct PreprocessingExecution<D: Domain> {
@@ -160,7 +161,7 @@ impl<D: Domain> PreprocessingExecution<D> {
         corrections: &mut CW,                        // player 0 corrections
         masks: &mut MW,                              // masks for online phase
         ab_gamma: &mut Vec<D::Sharing>,              // a * b + \gamma sharings for online phase
-        fieldswitching_input: Vec<usize>,
+        fieldswitching_input: HashSet<usize>,
         fieldswitching_output: Vec<Vec<usize>>,
     ) {
         // invariant: multiplication batch empty at the start

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -279,6 +279,8 @@ mod tests {
     use crate::util::eval::evaluate_program;
 
     use super::*;
+    use crate::fieldswitching::util::DedupMap;
+    use std::collections::HashSet;
 
     #[derive(Debug, Clone)]
     struct TestVector<D: Domain> {
@@ -674,14 +676,14 @@ mod tests {
                 test.branches.clone(),
                 test.input.clone(),
                 test.branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
                 .verify(
                     None,
                     test.program.clone(),
                     test.branches.clone(),
-                    (vec![], vec![]),
+                    (HashSet::new(), DedupMap::new()),
                 )
                 .unwrap();
             assert_eq!(verifier_output, output);
@@ -701,10 +703,10 @@ mod tests {
                 branches.clone(),
                 input,
                 branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
-                .verify(None, program, branches, (vec![], vec![]))
+                .verify(None, program, branches, (HashSet::new(), DedupMap::new()))
                 .unwrap();
             assert_eq!(verifier_output, output);
         }
@@ -722,10 +724,10 @@ mod tests {
                 branches.clone(),
                 input,
                 branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
-                .verify(None, program, branches, (vec![], vec![]))
+                .verify(None, program, branches, (HashSet::new(), DedupMap::new()))
                 .unwrap();
             assert_eq!(verifier_output, output);
         }
@@ -743,10 +745,10 @@ mod tests {
                 branches.clone(),
                 input,
                 branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
-                .verify(None, program, branches, (vec![], vec![]))
+                .verify(None, program, branches, (HashSet::new(), DedupMap::new()))
                 .unwrap();
             assert_eq!(verifier_output, output);
         }
@@ -764,10 +766,10 @@ mod tests {
                 branches.clone(),
                 input,
                 branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
-                .verify(None, program, branches, (vec![], vec![]))
+                .verify(None, program, branches, (HashSet::new(), DedupMap::new()))
                 .unwrap();
             assert_eq!(verifier_output, output);
         }
@@ -788,10 +790,10 @@ mod tests {
                 branches.clone(),
                 input,
                 branch_index,
-                (vec![], vec![]),
+                (HashSet::new(), DedupMap::new()),
             );
             let verifier_output = proof
-                .verify(None, program, branches, (vec![], vec![]))
+                .verify(None, program, branches, (HashSet::new(), DedupMap::new()))
                 .unwrap();
             assert_eq!(verifier_output, output);
         }

--- a/src/util/eval.rs
+++ b/src/util/eval.rs
@@ -82,10 +82,11 @@ pub fn evaluate_fieldswitching_btoa_program<D: Domain, D2: Domain>(
         }
     }
 
-    let (out_wires, output1): (Vec<usize>, Vec<D::Scalar>) = evaluate_program::<D>(program1, inputs, branch1, None);
+    let (out_wires, output1): (Vec<usize>, Vec<D::Scalar>) =
+        evaluate_program::<D>(program1, inputs, branch1, None);
     let mut out_map: HashMap<usize, D::Scalar> = HashMap::new();
 
-    for (index, value) in out_wires.iter().zip(output1.iter()){
+    for (index, value) in out_wires.iter().zip(output1.iter()) {
         out_map.insert(*index, *value);
     }
 
@@ -102,8 +103,13 @@ pub fn evaluate_fieldswitching_btoa_program<D: Domain, D2: Domain>(
                     if i >= D2::NR_OF_BITS {
                         break;
                     }
-                    let val: D::Scalar = out_map.get(&src_bit)
-                        .expect(format!("Couldn't find wire {} in boolean circuit output", src_bit).as_str()).clone();
+                    let val: D::Scalar = out_map
+                        .get(&src_bit)
+                        .expect(
+                            format!("Couldn't find wire {} in boolean circuit output", src_bit)
+                                .as_str(),
+                        )
+                        .clone();
                     input = input + convert_bit::<D, D2>(val) * pow_two;
                     pow_two = two * pow_two;
                 }

--- a/src/util/eval.rs
+++ b/src/util/eval.rs
@@ -90,7 +90,6 @@ pub fn evaluate_fieldswitching_btoa_program<D: Domain, D2: Domain>(
         out_map.insert(*index, *value);
     }
 
-
     let mut wires1 = Vec::new();
 
     for step in conn_program {
@@ -103,13 +102,9 @@ pub fn evaluate_fieldswitching_btoa_program<D: Domain, D2: Domain>(
                     if i >= D2::NR_OF_BITS {
                         break;
                     }
-                    let val: D::Scalar = out_map
-                        .get(&src_bit)
-                        .expect(
-                            format!("Couldn't find wire {} in boolean circuit output", src_bit)
-                                .as_str(),
-                        )
-                        .clone();
+                    let val: D::Scalar = *out_map.get(&src_bit).unwrap_or_else(|| {
+                        panic!("Couldn't find wire {} in boolean circuit output", src_bit)
+                    });
                     input = input + convert_bit::<D, D2>(val) * pow_two;
                     pow_two = two * pow_two;
                 }


### PR DESCRIPTION
Several of the I/O constructs used in fieldswitching use `Vec.contains` within loops, which blows up our runtime on large binaries. This PR attempts to fix that, but needs more testing for soundness before it can be merged. 