### PR TITLE
Remove branches

### DIFF
--- a/companion/src/instruction/bristol.rs
+++ b/companion/src/instruction/bristol.rs
@@ -177,10 +177,6 @@ impl Parser<Instruction<BitScalar>> for InsParser {
                 let src = ins[0].parse().unwrap();
                 Ok(Some(Instruction::Output(src)))
             }
-            "BRANCH" => {
-                let dst = ins[0].parse().unwrap();
-                Ok(Some(Instruction::Branch(dst)))
-            }
             "BUF" | "EQW" => {
                 let src = ins[0].parse().unwrap();
                 let dst = ins[1].parse().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub enum Instruction<E: RingElement> {
     Mul(usize, usize, usize),  // multiplication of two wires
     Add(usize, usize, usize),  // addition of two wires
     Sub(usize, usize, usize),  // subtraction of one wire from another
-    Branch(usize),             // load next branch element
     Input(usize),              // read next field element from input tape
     Output(usize),             // output wire (write wire-value to output tape)
     Const(usize, E),           // fixed constant value

--- a/src/online/mod.rs
+++ b/src/online/mod.rs
@@ -30,7 +30,6 @@ pub struct Chunk {
 pub struct Run<D: Domain> {
     open: TreePrf,         // randomness for opened players
     proof: MerkleSetProof, // merkle proof for masked branch
-    branch: Vec<u8>,       // masked branch (packed)
     commitment: Hash,      // commitment for hidden preprocessing player
     _ph: PhantomData<D>,
 }

--- a/src/online/verifier.rs
+++ b/src/online/verifier.rs
@@ -97,23 +97,12 @@ impl<D: Domain> StreamingVerifier<D> {
             let mut masked_witness_upstream: Vec<D::Scalar> = Vec::with_capacity(DEFAULT_CAPACITY);
 
             // check branch proof
-            let (root, mut branch) = {
-                // unpack bytes
-                let mut branch: Vec<D::Batch> = Vec::with_capacity(DEFAULT_CAPACITY);
-                Packable::unpack(&mut branch, &run.branch[..]).ok()?;
-
+            let root = {
                 // hash the branch
-                let mut hasher = RingHasher::new();
-                let mut scalars = Vec::with_capacity(branch.len() * D::Batch::DIMENSION);
-                for elem in branch.into_iter() {
-                    for j in 0..D::Batch::DIMENSION {
-                        scalars.push(elem.get(j))
-                    }
-                    hasher.update(elem)
-                }
+                let hasher: RingHasher<D::Batch> = RingHasher::new();
 
                 // recompute the Merkle root from the leaf and proof
-                (run.proof.verify(&hasher.finalize()), scalars.into_iter())
+                run.proof.verify(&hasher.finalize())
             };
 
             loop {
@@ -189,9 +178,6 @@ impl<D: Domain> StreamingVerifier<D> {
                                                 wires.get(dst)
                                             );
                                         }
-                                    }
-                                    Instruction::Branch(dst) => {
-                                        wires.set(dst, branch.next()?);
                                     }
                                     Instruction::Const(dst, c) => {
                                         wires.set(dst, c);

--- a/src/preprocessing/preprocessing.rs
+++ b/src/preprocessing/preprocessing.rs
@@ -30,12 +30,13 @@ pub struct PreprocessingExecution<D: Domain> {
 }
 
 impl<D: Domain> PreprocessingExecution<D> {
-    pub fn new(root: [u8; KEY_SIZE], branches: &[Vec<D::Batch>]) -> Self {
+    pub fn new(root: [u8; KEY_SIZE]) -> Self {
         // expand repetition seed into per-player seeds
         let mut player_seeds: Vec<[u8; KEY_SIZE]> = vec![[0u8; KEY_SIZE]; D::PLAYERS];
         TreePrf::expand_full(&mut player_seeds, root);
 
         // mask the branches and compute the root of the Merkle tree
+        let branches = vec![vec![]];
         let root: Hash = {
             let mut hashes: Vec<RingHasher<D::Batch>> =
                 (0..branches.len()).map(|_| RingHasher::new()).collect();
@@ -135,9 +136,6 @@ impl<D: Domain> PreprocessingExecution<D> {
                 }
                 Instruction::Input(dst) => {
                     self.masks.set(dst, self.shares.input.next());
-                }
-                Instruction::Branch(dst) => {
-                    self.masks.set(dst, self.shares.branch.next());
                 }
                 Instruction::Const(dst, _c) => {
                     // We don't need to mask constant inputs because the circuit is public

--- a/src/preprocessing/verifier.rs
+++ b/src/preprocessing/verifier.rs
@@ -167,13 +167,6 @@ impl<D: Domain> PreprocessingExecution<D> {
                 Instruction::LocalOp(dst, src) => {
                     self.masks.set(dst, self.masks.get(src).operation());
                 }
-                Instruction::Branch(dst) => {
-                    // check if need for new batch of branch masks
-                    let mask = self.shares.branch.next();
-
-                    // assign the next unused branch share to the destination wire
-                    self.masks.set(dst, mask);
-                }
                 Instruction::Input(dst) => {
                     // check if need for new batch of input masks
                     let mask = self.shares.input.next();


### PR DESCRIPTION
Removes branching instructions and the necessary infrastructure to handle them. They were originally intended for set membership verification, but as we don't use them in our circuit design and the rest of our pipeline doesn't support them, we're removing them as unnecessary complexity.