### PR TITLE
Derive Default for GF2 Recon & Share

### DIFF
--- a/src/algebra/gf2/recon.rs
+++ b/src/algebra/gf2/recon.rs
@@ -9,7 +9,7 @@ use crate::algebra::{EqIndex, Hashable, Pack, Recon};
 use crate::crypto::hash::PackedHasher;
 use crate::PACKED;
 
-#[derive(Copy, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, PartialEq, Eq, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ReconGF2 {
     pub(crate) pack: u64,
 }
@@ -268,12 +268,6 @@ impl ReconGF2 {
             valid &= *bit == 0xff || *bit == 0x00;
         }
         valid
-    }
-}
-
-impl Default for ReconGF2 {
-    fn default() -> Self {
-        ReconGF2 { pack: 0 }
     }
 }
 

--- a/src/algebra/gf2/share.rs
+++ b/src/algebra/gf2/share.rs
@@ -11,7 +11,7 @@ use super::domain::byte_to_shares_x86;
 
 use std::convert::TryFrom;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct ShareGF2 {
     pub(crate) pack: u64,
 }
@@ -207,12 +207,6 @@ impl PackSelected for ShareGF2 {
             // copy partial shares to destination
             dst.extend_from_slice(&tmp_dst);
         }
-    }
-}
-
-impl Default for ShareGF2 {
-    fn default() -> Self {
-        ShareGF2 { pack: 0 }
     }
 }
 


### PR DESCRIPTION
Fixes the new clippy lint that has been causing the tests to fail.